### PR TITLE
Add feature change all the required hours number at once #55.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -77,6 +77,22 @@ class UsersController < ApplicationController
     redirect_to marketplace_path(@user)
   end
 
+  def update_mult_required_hours
+    authorize :user
+    required_hours = params[:required_hours].to_f
+    if required_hours >= 0 and required_hours <= HOURS_PER_WEEK and params[:user_ids] != nil
+      for user_id in params[:user_ids].keys
+        @user = User.find_by_id(user_id)
+        @user.update_required_hours(required_hours)
+      end
+    elsif params[:user_ids] == nil
+      flash[:alert] = 'Select at least one user to update Required Weekly Hours.'
+    else
+      flash[:alert] = "Required hours should be equal or greater than 0 but equal or less than #{HOURS_PER_WEEK}."
+    end
+    redirect_to roster_path(@user)
+  end
+
   def update_required_hours
     authorize :user
     @user = User.find_by_id(params[:id])

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -11,6 +11,10 @@ class UserPolicy < ApplicationPolicy
     user.workshift_manager?
   end
 
+  def update_mult_required_hours?
+    user.workshift_manager?
+  end
+
   def update_workshift_selling_limit?
     user.workshift_manager?
   end

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,26 +1,41 @@
 .row
   .column.small-12
     %h1 House Roster
-  .column.small-12
-    %table.data-table#house_roster
-      %thead
-        %tr
-          %td Resident
-          %td Hours Balance
-          - if policy(:workshift).edit?
-            %td Hours Assigned / Hours Needed
-          %td Room Number
-          %td Email
-          %td Phone Number
-      %tbody
-        - @users.each do |user|
+  = form_tag update_mult_required_hours_path(@user) do
+    .column.small-12
+      %table.data-table#house_roster
+        %thead
           %tr
-            %td= link_to user.name, user_profile_path(user)
-            %td{ class: "#{user.hours_balance_class}" }= user.hours_balance
             - if policy(:workshift).edit?
-              %td{ class: "#{user.hours_assigned_class}" }
-                #{user.workshifts.sum(:hours)} / #{user.required_hours}
-            %td= (user.room_number.length > 0) ? user.room_number : ''
-            %td= (user.display_email?) ? user.email : ''
-            %td
-              = (user.display_phone_number? && user.phone_number.length > 0) ? user.phone_number : ''
+              %td Select
+            %td Resident
+            %td Hours Balance
+            - if policy(:workshift).edit?
+              %td Hours Assigned / Hours Needed
+            %td Room Number
+            %td Email
+            %td Phone Number
+        %tbody
+          - @users.each do |user|
+            %tr
+              - if policy(:workshift).edit?
+                %td= check_box_tag "user_ids[#{user.id}]"
+              %td= link_to user.name, user_profile_path(user)
+              %td{ class: "#{user.hours_balance_class}" }= user.hours_balance
+              - if policy(:workshift).edit?
+                %td{ class: "#{user.hours_assigned_class}" }
+                  #{user.workshifts.sum(:hours)} / #{user.required_hours}
+              %td= (user.room_number.length > 0) ? user.room_number : ''
+              %td= (user.display_email?) ? user.email : ''
+              %td
+                = (user.display_phone_number? && user.phone_number.length > 0) ? user.phone_number : ''
+      - if policy(:workshift).edit?
+        .column.small-12
+          .settings-section
+          %fieldset
+            %legend Required Weekly Hours
+            .column.small-5
+              = label_tag :required_hours, 'New Required Hours'
+              = number_field_tag :required_hours, '3.0',
+                      step: 0.5
+              = submit_tag 'Change Required Hours', class: 'button small'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ WorkshiftWebsite::Application.routes.draw do
     get 'settings/preferences' => :preferences, as: :preferences
     delete 'residents/delete/all' => :delete_all, as: :delete_all_users
     post 'residents/add' => :add_users, as: :invite_users
+    post 'residents/settings/required_hours' => :update_mult_required_hours,
+         as: :update_mult_required_hours
     post 'settings/preferences/categories' => :update_category_preferences,
          as: :update_category_preferences
     post 'settings/preferences/schedule' => :update_schedule,


### PR DESCRIPTION
Add a select checkbox in front of each user on the house roster (path: /residents) and a Required Weekly Hours box at the end of the page to update all the users selected.