### PR TITLE
dropdown selector for updating user unit

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
   def profile
     id = params[:id] || current_user.id
     @user = User.where(unit_id: current_user.unit).find(id)
+    @other_units = (Unit.all.size == 1) ? Unit.all : Unit.find(:all, :conditions => ["id != ?", @user.id])
     @quiet_hours = Quiet_hours.new
     @preferences = @user.sorted_preferences
     @verifier_list = User.all.map {|c| c.attributes.slice("name", "id")}
@@ -100,6 +101,9 @@ class UsersController < ApplicationController
     unit = Unit.find_by_name(params[:unit])
     if unit == nil
       flash[:alert] = "No such unit exists : #{params[:unit]}."
+      redirect_to user_profile_path(@user) and return
+    elsif unit.id == @user.unit.id
+      flash[:alert] = "User is already in selected unit : #{params[:unit]}."
       redirect_to user_profile_path(@user) and return
     else
       @user.preferences.destroy_all

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -59,14 +59,17 @@
           - if policy(:user).update_unit?
             .settings-section
               %fieldset
-                %legend Unit
+                %legend Select a unit:
+                .column.small-5
                 %p Current Unit: #{@user.unit.name}
                 %p Warning, you cannot retrieve the user after sending him to an other unit.
                 = form_tag update_unit_path(@user) do
-                  .column.small-5
-                    = label_tag :unit, 'New Unit name, must exist'
-                    = text_field_tag :unit
+                  %select{:name => 'unit'}
+                    %option{value: -1}=""
+                    - @other_units.each do |unit|
+                      %option{value: unit.name}= unit.name
                   = submit_tag 'Change Unit', class: 'button small'
+
   .column.small-12.medium-4
     %table#user_category_preferences
       %thead

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -77,6 +77,11 @@ describe UsersController do
       @workshift_assignment = create(:workshift_assignment, id: 2, workshifter: @user)
     end
 
+    it 'redirects to the user page if user is already in the selected unit' do
+      post :update_unit, unit: 'Unit 1', id: @user.id
+      expect(response).to redirect_to(user_profile_path(@user))
+    end
+
     it 'removes preferences from user' do
       expect(@user.preferences.first).to eq(@preference)
       post :update_unit, unit: 'Unit 2', id: @user.id


### PR DESCRIPTION
this changes the unit text box on the profile page to a dropdown. it also fixes a bug where transferring a user to the unit the user is already in deletes all the user's preferences and unassigns workshifts.