### PR TITLE
Feature/quiethours

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < ApplicationController
     @other_units = (Unit.all.size == 1) ? Unit.all : Unit.find(:all, :conditions => ["id != ?", @user.id])
     if not @user.unit.nil?
       @quiet_hours = @user.unit.quiet_hour
+    end
     @preferences = @user.sorted_preferences
     @verifier_list = User.all.map {|c| c.attributes.slice("name", "id")}
     @workshift_assignments = @user.workshift_assignments.select do |assignment|

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,8 @@ class UsersController < ApplicationController
     id = params[:id] || current_user.id
     @user = User.where(unit_id: current_user.unit).find(id)
     @other_units = (Unit.all.size == 1) ? Unit.all : Unit.find(:all, :conditions => ["id != ?", @user.id])
-    @quiet_hours = @user.unit.quiet_hour
+    if not @user.unit.nil?
+      @quiet_hours = @user.unit.quiet_hour
     @preferences = @user.sorted_preferences
     @verifier_list = User.all.map {|c| c.attributes.slice("name", "id")}
     @workshift_assignments = @user.workshift_assignments.select do |assignment|

--- a/app/models/day_quiet_hour.rb
+++ b/app/models/day_quiet_hour.rb
@@ -1,0 +1,4 @@
+class DayQuietHour < ActiveRecord::Base
+  belongs_to :quiet_hour
+  attr_accessible :start_time, :end_time, :day, :quiet_hour_id
+end

--- a/app/models/quiet_hour.rb
+++ b/app/models/quiet_hour.rb
@@ -1,0 +1,42 @@
+class QuietHour < ActiveRecord::Base
+  belongs_to :unit
+  has_many :day_quiet_hours
+
+  attr_accessible :day_quiet_hours, :quiet_hour_id
+
+  def get_day_start_time(day)
+    day_quiet_hours.where(day: day).first.start_time
+  end
+
+  def get_day_end_time(day)
+    day_quiet_hours.where(day: day).first.end_time
+  end
+
+  def set_day_start_time(day, start_time)
+    if day == 'weekdays'
+      ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday'].each do |weekday|
+        day_quiet_hours.where(day: weekday).update_all(:start_time => start_time)
+      end
+    elsif day == 'weekends'
+      ['friday', 'saturday'].each do |weekend|
+        day_quiet_hours.where(day: weekend).update_all(:start_time => start_time)
+      end
+    else
+      day_quiet_hours.where(day: day).first.update_attributes(:start_time => start_time)
+    end
+  end
+
+  def set_day_end_time(day, end_time)
+    if day == 'weekdays'
+      ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'].each do |weekday|
+        day_quiet_hours.where(day: weekday).update_all(:end_time => end_time)
+      end
+    elsif day == 'weekends'
+      ['saturday', 'sunday'].each do |weekend|
+        day_quiet_hours.where(day: weekend).update_all(:end_time => end_time)
+      end
+    else
+      day_quiet_hours.where(day: day).first.update_attributes(:end_time => end_time)
+    end
+  end
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,11 +1,12 @@
 class Unit < ActiveRecord::Base
-   attr_accessible :name
+   attr_accessible :name, :quiet_hour
 
    has_many :users
    has_many :workshifts
    has_many :workshift_assignments
    has_many :categories
    has_many :weekly_reports
+   has_one :quiet_hour
 
    validates :name, presence: true
 end

--- a/app/views/users/profile.html.haml
+++ b/app/views/users/profile.html.haml
@@ -33,26 +33,47 @@
                     = number_field_tag :required_hours, @user.required_hours,
                       step: 0.5
                     = submit_tag 'Change Required Hours', class: 'button small'
+
         .column.small-12
           - if policy(:user).update_quiet_hours?
             .settings-section
               %fieldset
-                %legend Quiet hours
-                %p
-                  :markdown
-                    The current quiet hours are effective between: <strong>#{@quiet_hours.get_quiet_hours_str}</strong>
-                = form_tag update_quiet_hours_path(@user) do
+                %legend Quiet Hours
+                - if @quiet_hours.nil?
+                  %p No quiet hours have been set for the unit.
+                - else
                   %table
                     %thead
                       %tr
-                        %td From
-                        %td To
+                        %td Day
+                        %td End Time
+                        %td Start Time
+                    %tbody
+                      - ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'].each do |day|
+                        %tr
+                          %td= day
+                          - day_quiet_hours = @quiet_hours.day_quiet_hours.where(day: day.downcase).first
+                          %td= day_quiet_hours.end_time.nil? ? 'Not Set' : day_quiet_hours.end_time.strftime("%I:%M %p")
+                          %td= day_quiet_hours.start_time.nil? ? 'Not Set' : day_quiet_hours.start_time.strftime("%I:%M %p")
+                %p Set Quiet Hours:
+                = form_tag(update_quiet_hours_path(@user), :method => :post) do
+                  %select{:name => 'day'}
+                    %p Day: 
+                    %option{value: "Sunday"}="Sunday"
+                    - ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Weekdays', 'Weekends'].each do |day|
+                      %option{value: day}= day
+                  %p Note: selecting Weekdays sets quiet hours for the nights before weekdays, while Weekends sets Friday and Saturday nights.
+                  %table
+                    %thead
+                      %tr
+                        %td Ending At
+                        %td Starting At
                     %tbody
                       %tr
-                        %td= time_select 'start_quiet_hours', 'start_quiet_hours',
-                              {ampm: true, minute_step: 5, ignore_date: true, time_separator: ''}
-                        %td= time_select 'stop_quiet_hours', 'stop_quiet_hours',
-                              {ampm: true, minute_step: 5, ignore_date: true, time_separator: ''}
+                        %td= time_select 'end_time', 'end_time',
+                              {ampm: true, minute_step: 5, ignore_date: true, time_separator: '', default: { hour: '8', minute: '0' } }
+                        %td= time_select 'start_time', 'start_time',
+                              { ampm: true, minute_step: 5, ignore_date: true, time_separator: '', default: { hour: '22', minute: '0' } }
                   = submit_tag 'Update Quiet Hours', class: 'button small'
 
         .column.small-12

--- a/db/migrate/20151122052655_create_quiet_hours.rb
+++ b/db/migrate/20151122052655_create_quiet_hours.rb
@@ -1,0 +1,7 @@
+class CreateQuietHours < ActiveRecord::Migration
+  def change
+  	create_table :quiet_hours do |t|
+  		t.integer :unit_id
+  	end
+  end
+end

--- a/db/migrate/20151122173816_create_day_quiet_hours.rb
+++ b/db/migrate/20151122173816_create_day_quiet_hours.rb
@@ -1,0 +1,10 @@
+class CreateDayQuietHours < ActiveRecord::Migration
+  def change
+    create_table :day_quiet_hours do |t|
+      t.integer :quiet_hour_id
+      t.time :start_time
+      t.time :end_time
+      t.string :day
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151029222505) do
+ActiveRecord::Schema.define(:version => 20151122173816) do
 
   create_table "assigned_workshifts", :force => true do |t|
     t.integer  "workshift_id"
@@ -31,12 +31,23 @@ ActiveRecord::Schema.define(:version => 20151029222505) do
     t.integer  "unit_id"
   end
 
+  create_table "day_quiet_hours", :force => true do |t|
+    t.integer "quiet_hour_id"
+    t.time    "start_time"
+    t.time    "end_time"
+    t.string  "day"
+  end
+
   create_table "preferences", :force => true do |t|
     t.integer  "rank"
     t.integer  "category_id"
     t.integer  "user_id"
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
+  end
+
+  create_table "quiet_hours", :force => true do |t|
+    t.integer "unit_id"
   end
 
   create_table "units", :force => true do |t|

--- a/spec/factories/day_quiet_hours.rb
+++ b/spec/factories/day_quiet_hours.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :day_quiet_hour, :class => 'DayQuietHour' do
+    quiet_hours nil
+  end
+
+end

--- a/spec/factories/day_quiet_hours.rb
+++ b/spec/factories/day_quiet_hours.rb
@@ -1,6 +1,5 @@
 FactoryGirl.define do
   factory :day_quiet_hour, :class => 'DayQuietHour' do
-    quiet_hours nil
   end
 
 end

--- a/spec/factories/quiet_hours.rb
+++ b/spec/factories/quiet_hours.rb
@@ -1,7 +1,5 @@
 FactoryGirl.define do
   factory :quiet_hour, :class => 'QuietHour' do
-    day_quiet_hours nil
-    quiet_hour_id nil
   end
 
 end

--- a/spec/factories/quiet_hours.rb
+++ b/spec/factories/quiet_hours.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :quiet_hour, :class => 'QuietHour' do
+    day_quiet_hours nil
+    quiet_hour_id nil
+  end
+
+end

--- a/spec/models/quiet_hours_spec.rb
+++ b/spec/models/quiet_hours_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe QuietHour do
+	before(:each) do
+		@quiet_hour = create(:quiet_hour)
+    @most_start_time = Time.parse('9:00PM')
+    @most_end_time = Time.parse('10:00AM')
+    ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'].each do |day|
+      day_quiet_hour = create(:day_quiet_hour)
+      day_quiet_hour.save
+      day_quiet_hour.update_attributes(day: day)
+      @quiet_hour.day_quiet_hours << day_quiet_hour
+      day_quiet_hour.save
+      @quiet_hour.day_quiet_hours.where(day: day).first.update_attributes(:start_time => @most_start_time, :end_time => @most_end_time)
+    end
+    @other_start_time = Time.parse('10:00PM')
+    @other_end_time = Time.parse('11:00AM')
+    @quiet_hour.day_quiet_hours.where(day: 'monday').first.update_attributes(:start_time => @other_start_time, :end_time => @other_end_time)
+	end
+
+	describe 'getting the start and end times for some day' do
+		it 'returns the start time of the correct day' do
+			expect(@quiet_hour.get_day_start_time('sunday').seconds_since_midnight).to eq(@most_start_time.seconds_since_midnight)
+			expect(@quiet_hour.get_day_start_time('monday').seconds_since_midnight).to eq(@other_start_time.seconds_since_midnight)
+		end
+		it 'returns the end time of the correct day' do
+			expect(@quiet_hour.get_day_end_time('sunday').seconds_since_midnight).to eq(@most_end_time.seconds_since_midnight)
+			expect(@quiet_hour.get_day_end_time('monday').seconds_since_midnight).to eq(@other_end_time.seconds_since_midnight)
+		end
+	end
+
+	describe 'setting start and end times for some day' do
+		it 'sets the start time of the correct day' do
+			@quiet_hour.set_day_start_time('tuesday', @other_start_time)
+			expect(@quiet_hour.get_day_start_time('tuesday').seconds_since_midnight).to eq(@other_start_time.seconds_since_midnight)
+		end
+		it 'sets the end time of the correct day' do
+			@quiet_hour.set_day_end_time('wednesday', @other_end_time)
+			expect(@quiet_hour.get_day_end_time('wednesday').seconds_since_midnight).to eq(@other_end_time.seconds_since_midnight)
+		end
+	end
+end


### PR DESCRIPTION
this introduces the quiet hours feature

unit-level admins and workshift managers can set the quiet hours for the unit on the profile page. all users of the house will see the quiet hours on their profile pages.